### PR TITLE
Workaround browse provided

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -10,6 +10,9 @@ var offset=0;
 searchType="search";
 pageURL="";
 
+//need global variable catalogURL to provide browsing workaround
+var catalogKeywords="";
+
 //main program
 $.getJSON( buildSearch(), function( data ) {
   response=data;
@@ -43,6 +46,9 @@ if (searchType == "search"){
   //Set keywords from form in index.html, restricted to online records mentioning Alaska
  var keywords = $("#keywords").val();
  akURL=akURL + "q=" + keywords + " and alaska &exists=objects";
+
+ //Create a workaround catalog URL to browse next set of records in full NARA catalog
+ catalogKeywords = keywords;
 
 //Set keywords from form in index.html, restricted to records mentioning Alaska Digitization Project
 //  akURL=akURL + "q=" + keywords + " and \"Alaska%20Digitization%20Project\"";
@@ -101,6 +107,11 @@ function displayResults(results) {
    $("#recent").append("<p style=\"border-bottom-style: solid\"></p>" );
 
   } // end display loop
+
+//Temporary paging workaround
+ $("#recent").append("</br><a href=\"https://catalog.archives.gov/search?q=" + catalogKeywords + "%20and%20alaska%20&resultTypes=item,fileUnit&tabType=online&offset=10\" target=\"_blank\">See next 10 records</a> in full National Archives Catalog.");
+ $("#recent").append("</br>This browse into the full catalog is offered because we cannot current page through results here. Link opens into the official National Catalog in a new tab.")
+
   clearTimeout(naraRequestTimeout);
 
 //Functions local to DisplayResults


### PR DESCRIPTION
Clicking next ten records link opens new tab into NARA catalog starting with record 11.

<!-- Which issue does this close? -->
This is a workaround for 10, No paging results for searches.

<!-- What did you do? -->
- Fed search keywords into a URL that links into the full NARA catalog. Needed to create global variable catalogKeywords to be used in both buildSearch and displayResults.
- 

<!-- How can this be tested? -->
QA:
- [ ] Do a search and click a link. If using same keyword it passes.
- [ ]
